### PR TITLE
enabling chef_handler immediately to make it available during compile phase

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,6 @@ description 'Installs/Configures hipchat_handler'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/BarthV/chef-hipchat_handler' if respond_to?(:source_url)
 issues_url 'https://github.com/BarthV/chef-hipchat_handler/issues' if respond_to?(:issues_url)
-version '0.1.7'
+version '0.1.8'
 
 depends 'chef_handler'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,4 +34,4 @@ chef_handler 'Chef::Handler::Hipchat' do
   arguments [
     node['chef_client']['handler']['hipchat']
   ]
-end
+end.run_action(:enable)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ cookbook_file handler_file do
   source 'hipchat_handler.rb'
   mode '0600'
   action :create
-end
+end.run_action(:create)
 
 chef_handler 'Chef::Handler::Hipchat' do
   source handler_file


### PR DESCRIPTION
@BarthV Thanks for the info you gave me on https://github.com/BarthV/chef-hipchat_handler/issues/2#issuecomment-165132623

I went ahead and tested that this works and confirms its working for me.

An execution time test (was already working)

```
$ cat cookbooks/cc-hipchat/recipes/fail_execution.rb 
ruby_block "failure" do
  block do
    raise "FAILURE!"
  end
end
```

A compile time test

```
$ cat cookbooks/cc-hipchat/recipes/fail_compile.rb 
node.somebsattr.split('')
```
