### PR TITLE
Add support for Hipchat server, allow enable/disable of room notification, some cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Attributes
 
 Optional attributes
 
+* `node['chef_client']['handler']['hipchat']['server_url']` - The Hipchat API server URL (default: 'https://api.hipchat.com')
 * `node['chef_client']['handler']['hipchat']['emoji_url']` - The message emoji icon url (default: nil)
 * `node['chef_client']['handler']['hipchat']['detail_level']` - The level of detail in the message. Valid options are `basic`, `elapsed` (default: 'basic')
 * `node['chef_client']['handler']['hipchat']['report_success']` - Report to Hipchat even when run is successful (default: false)
+* `node['chef_client']['handler']['hipchat']['notify_users']` - Enable / disable notification on message (default: true)
 * `node['chef_client']['handler']['hipchat']['timeout']` - Hipchat connector timeout in seconds (default: 10)
 
 Credits

--- a/files/default/hipchat_handler.rb
+++ b/files/default/hipchat_handler.rb
@@ -47,8 +47,8 @@ class Chef
           return
         when 'elapsed'
           "(#{run_status.elapsed_time} seconds). #{updated_resources.count} resources updated" unless updated_resources.nil?
-        when "resources"
-          "(#{run_status.elapsed_time} seconds). #{updated_resources.count} resources updated\n#{updated_resources.join(", ").to_s}"  unless updated_resources.nil?
+        when 'resources'
+          "(#{run_status.elapsed_time} seconds). #{updated_resources.count} resources updated\n#{updated_resources.join(', ')}" unless updated_resources.nil?
         else
           return
         end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ cookbook_file File.join(node['chef_handler']['handler_path'], 'hipchat_handler.r
 end
 
 chef_handler 'Chef::Handler::Hipchat' do
-  source '/var/chef/handlers/hipchat_handler.rb'
+  source File.join(node['chef_handler']['handler_path'], 'hipchat_handler.rb')
   arguments [
     node['chef_client']['handler']['hipchat']
   ]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ cookbook_file File.join(node['chef_handler']['handler_path'], 'hipchat_handler.r
 end
 
 chef_handler 'Chef::Handler::Hipchat' do
-  source File.join(node['chef_handler']['handler_path'], 'hipchat_handler.rb')
+  source '/var/chef/handlers/hipchat_handler.rb'
   arguments [
     node['chef_client']['handler']['hipchat']
   ]


### PR DESCRIPTION
Hi there,

This PR adds support for Hipchat server by allowing configuration of the Hipchat server URL. It also allows you to enable or disable room notification, and detail level 'resources' now also reports a list of updated resources.

I also did some cleanups (probably some leftovers of the slack_handler :) )
