### PR TITLE
Remove run-time chef_gem warnings.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,9 @@ MethodLength:
   Enabled: false
 SignalException:
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
+  Enabled: false
+TrailingCommaInArguments:
   Enabled: false
 WordArray:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,15 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'berkshelf', '~> 3.3.0'
+gem 'berkshelf', '~> 4.3.0'
 gem 'stove'
 
 group :test do
-  gem 'foodcritic', '~> 4.0.0'
-  gem 'rubocop', '~> 0.33.0'
+  gem 'foodcritic', '~> 6.0.1'
+  gem 'rubocop', '~> 0.38.0'
 end
 
 group :integration do
-  gem 'test-kitchen', '~> 1.4.2'
-  gem 'kitchen-vagrant', '~> 0.18.0'
+  gem 'test-kitchen', '~> 1.7.2'
+  gem 'kitchen-vagrant', '~> 0.20.0'
 end

--- a/files/default/hipchat_handler.rb
+++ b/files/default/hipchat_handler.rb
@@ -68,7 +68,7 @@ class Chef
         if @emoji_url.nil?
           ''
         else
-          %(#{'<img src=' + @emoji_url + '> '})
+          "<img src=#{emoji_url}> "
         end
       end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,9 @@
 
 include_recipe 'chef_handler'
 
-chef_gem 'hipchat'
+chef_gem 'hipchat' do
+  compile_time false if respond_to?(:compile_time)
+end
 
 handler_file = File.join(node['chef_handler']['handler_path'], 'hipchat_handler.rb')
 


### PR DESCRIPTION
See notes on `compile_time` at https://docs.chef.io/resource_chef_gem.html#properties.

Hi. I see you have 0.1.9 lined up for release to supermarket. Would you add my small tweak, that kills deprecation warnings on the latest Chef clients, and go ahead with your release, please? I'd like to use your 0.1.9 changes and have my small fix in place too.

Cheers,
Andrew.
